### PR TITLE
[pr-check] Disable github-token parameter.

### DIFF
--- a/pr-check/action.yml
+++ b/pr-check/action.yml
@@ -1,10 +1,6 @@
 name: 'Pull request check'
 description: 'Checks if a pull request meets a set of requirements.'
 inputs:
-  github-token:
-    description: 'GitHub token with read and write access on the project.'
-    required: true
-
   source-path:
     description: 'Path where the source code is located. If set, will only enforce proper linting if a change targets that path.'
     required: false

--- a/pr-check/index.js
+++ b/pr-check/index.js
@@ -102,15 +102,12 @@ async function run() {
     const payload = github.context.payload;
 
     if (payload.hasOwnProperty('pull_request')) {
-      const projectName = payload.repository.name;
       const description = payload.pull_request.body.replace(/\r\n/g, '\n');
       const env = {
         owner: payload.repository.owner.login,
         repo: payload.repository.name,
         pull_number: payload.pull_request.number,
-        octokit: new Octokit({
-          auth: core.getInput('github-token')
-        }),
+        octokit: new Octokit(),
       };
 
       var doLinting = true;


### PR DESCRIPTION
This patch fixes a bug where `pr-check` fails when used from a fork. It's caused by the fork not having the parent repo secret.

Here for example: https://github.com/EventStore/EventStore/runs/628804497?check_suite_focus=true

Where we got that stacktrace:
```
(node:3051) UnhandledPromiseRejectionWarning: HttpError: Requires authentication
    at /home/runner/work/_actions/EventStore/Automations/master/pr-check/node_modules/@octokit/request/dist-node/index.js:66:23
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async reportValidationStatus (/home/runner/work/_actions/EventStore/Automations/master/pr-check/index.js:63:5)
(node:3051) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:3051) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

 `pr-check` doesn't need a special token to do its thing, hence why the `github-token` is disabled/ignored.