### PR TITLE
Added ignoring of cherry-pick-pr-for-label action if PR was not merged

### DIFF
--- a/cherry-pick-pr-for-label/README.md
+++ b/cherry-pick-pr-for-label/README.md
@@ -19,7 +19,6 @@ on:
     types: [closed]
 jobs:
   cherry_pick:
-    if: github.event.pull_request.merged == 'true'
     name: Cherry Pick PR for label
     runs-on: ubuntu-latest
     steps:

--- a/cherry-pick-pr-for-label/index.js
+++ b/cherry-pick-pr-for-label/index.js
@@ -124,6 +124,11 @@ async function run() {
       return;
     }
 
+    if (pullRequest.merged !== true) {
+      console.log(`Skipping: PR was not merged.`);
+      return;
+    }
+
     let anyCherryPickFailed = false;
 
     for (const targetBranch of targetBranches) {


### PR DESCRIPTION
Previously the check was done on the workflow action level. However, that wasn't working, as the pipeline was ignored without any information.
This moves the check into GitHub action itself, plus adding login with information why it was ignored.