### PR TITLE
Pass the project number using secrets

### DIFF
--- a/.github/workflows/development-project-automation.yml
+++ b/.github/workflows/development-project-automation.yml
@@ -2,10 +2,6 @@ name: Development project automations
 on:
   workflow_call:
     inputs:
-      project-number:
-        required: true
-        description: The project number from the project's url
-        type: number
       resource-node-id:
         required: true
         description: The node id of the issue or PR to act upon
@@ -23,9 +19,12 @@ on:
       token:
         required: true
         description: The token to use. It must have org:write access
+      project-number:
+        required: true
+        description: The project number from the project's url
 
 env:
-  PROJECT_ID: ${{ inputs.project-number }}
+  PROJECT_ID: ${{ secrets.project-number }}
 jobs:
   milestone_added_to_issue:
     name: milestone_added_to_issue

--- a/.github/workflows/triage-project-automation.yml
+++ b/.github/workflows/triage-project-automation.yml
@@ -3,10 +3,6 @@ name: EventStore Triage Project Automations Workflow
 on:
   workflow_call:
     inputs:
-      project-number:
-        required: true
-        description: The project number from the project's url
-        type: number
       resource-node-id:
         required: true
         description: The node id of the issue or PR to act upon
@@ -23,7 +19,12 @@ on:
       token:
         required: true
         description: The token to use. It must have org:write access
+      project-number:
+        required: true
+        description: The project number from the project's url
 
+env:
+  PROJECT_NUMBER: ${{ secrets.project-number }}
 jobs:
   item-milestoned:
     name: Remove milestoned item
@@ -35,7 +36,7 @@ jobs:
         with:
           github-token: ${{ secrets.token }}
           organization: EventStore
-          project-number: ${{ inputs.project-number }}
+          project-number: ${{ env.PROJECT_NUMBER }}
           resource-node-id: ${{ inputs.resource-node-id }}
   item-added:
     name: Add item to board
@@ -46,6 +47,6 @@ jobs:
         with:
           gh_token: ${{ secrets.token }}
           organization: EventStore
-          project_id: ${{ inputs.project-number }}
+          project_id: ${{ env.PROJECT_NUMBER }}
           resource_node_id: ${{ inputs.resource-node-id }}
           status_value: "To Triage"

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Items that are given a milestone are removed from the Triage project, and should
 
 | Input                   | Description |
 | ------------------ | ------------- |
-| `project-number`       | The Project Number from the project's url |
 | `resource-node-id` | The global node ID of the issue or PR (`github.event.issue.node_id`) |
 | `event-action` | The action that triggered the workflow (`github.event.action`) |
 | `labels` | A comma-separated list of the labels on the issue (`join(github.event.issue.labels.*.name, ', ')`) |
 
 | Secrets                | Description |
 | ------------------ | ------------- |
+| `project-number`       | The Project Number from the project's url |
 | `token`                | Github Access Token with `org:write` permission |
 
 ### Example calling workflow:
@@ -35,13 +35,13 @@ on:
       - labeled
 jobs:
   call-workflow:
-    uses: EventStore/Automation/.github/workflows/triage-project-automation.yml@master
+    uses: EventStore/Automations/.github/workflows/triage-project-automation.yml@master
     with:
-      project-number: 1
       resource-node-id: ${{ github.event.issue.node_id }}
       event-action: ${{ github.event.action }}
       labels: ${{ join(github.event.issue.labels.*.name, ', ') }}
     secrets:
+      project-number: 1
       token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 ```
 
@@ -57,13 +57,13 @@ If the pull request is converted to draft or set to ready to review, then the st
 
 | Input                   | Description |
 | ------------------ | ------------- |
-| `project-number`       | The Project Number from the project's url |
 | `resource-node-id` | The global node ID of the issue or PR (`github.event.issue.node_id`) |
 | `event-action` | The action that triggered the workflow (`github.event.action`) |
 | `event-name` | The name of the event that triggered the workflow (`github.event_name`) |
 
 | Secrets                | Description |
 | ------------------ | ------------- |
+| `project-number`       | The Project Number from the project's url |
 | `token`                | Github Access Token with `org:write` permission |
 
 ### Example calling workflow:
@@ -81,13 +81,13 @@ on:
 
 jobs:
   call-workflow:
-    uses: EventStore/Automation/.github/workflows/development-project-automation.yml@master
+    uses: EventStore/Automations/.github/workflows/development-project-automation.yml@master
     with:
-      project-number: 2
       resource-node-id: ${{ github.event.pull_request.node_id }}
       event-action: ${{ github.event.action }}
       event-name: ${{ github.event_name }}
     secrets:
+      project-number: 2
       token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 ```
 
@@ -101,12 +101,12 @@ on:
 
 jobs:
   call-workflow:
-    uses: EventStore/Automation/.github/workflows/development-project-automation.yml@master
+    uses: EventStore/Automations/.github/workflows/development-project-automation.yml@master
     with:
-      project-number: 2
       resource-node-id: ${{ github.event.issue.node_id }}
       event-action: ${{ github.event.action }}
       event-name: ${{ github.event_name }}
     secrets:
+      project-number: 2
       token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 ```


### PR DESCRIPTION
Use secrets to pass the project number rather than inputs so that the project numbers can be stored in org secrets to avoid copying the project numbers into every repo.