### PR TITLE
Update project beta automations to latest version

### DIFF
--- a/.github/workflows/development-project-automation.yml
+++ b/.github/workflows/development-project-automation.yml
@@ -32,7 +32,7 @@ jobs:
     if: inputs.event-name == 'issues' && inputs.event-action == 'milestoned'
     steps:
       - name: 'Add issue to board'
-        uses: leonsteinhaeuser/project-beta-automations@v1.0.2
+        uses: leonsteinhaeuser/project-beta-automations@v1.2.1
         with:
           gh_token: ${{ secrets.token }}
           organization: EventStore
@@ -66,7 +66,7 @@ jobs:
               echo "::set-output name=prStatus::Review/QA"
             fi
       - name: 'Add Pull Request'
-        uses: leonsteinhaeuser/project-beta-automations@v1.0.2
+        uses: leonsteinhaeuser/project-beta-automations@v1.2.1
         with:
           gh_token: ${{ secrets.token }}
           organization: EventStore

--- a/.github/workflows/triage-project-automation.yml
+++ b/.github/workflows/triage-project-automation.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.event-action == 'opened' || inputs.event-action == 'reopened' || (inputs.event-action == 'labeled' && contains('triage', inputs.labels))
     steps:
-      - uses: leonsteinhaeuser/project-beta-automations@v1.0.2
+      - uses: leonsteinhaeuser/project-beta-automations@v1.2.1
         with:
           gh_token: ${{ secrets.token }}
           organization: EventStore


### PR DESCRIPTION
This contains a fix that is causing the project automations to fail when moving PR's. Release notes: https://github.com/leonsteinhaeuser/project-beta-automations/releases/tag/v1.2.1