### PR TITLE
Rename `GITHUB_TOKEN` -> `GH_TOKEN`

### DIFF
--- a/.github/workflows/development-project-automation.yml
+++ b/.github/workflows/development-project-automation.yml
@@ -49,7 +49,7 @@ jobs:
       - name: 'Get PR information'
         id: get_pr_info
         env:
-          GITHUB_TOKEN: ${{ secrets.token }}
+          GH_TOKEN: ${{ secrets.token }}
         run: |
           gh api graphql -f query='
             query($resource: ID!) {


### PR DESCRIPTION
Hello!

I submitted a PR to the EventStore dotnet client, and a few of the tests failed. It seems like I can fix this one😄 
![image](https://user-images.githubusercontent.com/21295394/214119068-4f9288ec-1220-4427-b627-bcebd3547118.png)
Failed test: https://github.com/EventStore/EventStore-Client-Dotnet/actions/runs/3970996878/jobs/6839695681