### PR TITLE
Update project next automations to v2

### DIFF
--- a/.github/workflows/development-project-automation.yml
+++ b/.github/workflows/development-project-automation.yml
@@ -32,7 +32,7 @@ jobs:
     if: inputs.event-name == 'issues' && inputs.event-action == 'milestoned'
     steps:
       - name: 'Add issue to board'
-        uses: leonsteinhaeuser/project-beta-automations@v1.2.1
+        uses: leonsteinhaeuser/project-beta-automations@v2.0.1
         with:
           gh_token: ${{ secrets.token }}
           organization: EventStore
@@ -66,7 +66,7 @@ jobs:
               echo "::set-output name=prStatus::Review/QA"
             fi
       - name: 'Add Pull Request'
-        uses: leonsteinhaeuser/project-beta-automations@v1.2.1
+        uses: leonsteinhaeuser/project-beta-automations@v2.0.1
         with:
           gh_token: ${{ secrets.token }}
           organization: EventStore

--- a/.github/workflows/triage-project-automation.yml
+++ b/.github/workflows/triage-project-automation.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.event-action == 'opened' || inputs.event-action == 'reopened' || (inputs.event-action == 'labeled' && contains('triage', inputs.labels))
     steps:
-      - uses: leonsteinhaeuser/project-beta-automations@v1.2.1
+      - uses: leonsteinhaeuser/project-beta-automations@v2.0.1
         with:
           gh_token: ${{ secrets.token }}
           organization: EventStore


### PR DESCRIPTION
This should fix the project board automations for adding issues and PRs according to [the readme](https://github.com/leonsteinhaeuser/project-beta-automations)

More work needs to be done on the scripts `bulk-add-issues-to-project`, and `delete-project-next-item`, but these are not used as much at the moment. See github's announcement [here](https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/) for more information about the necessary updates.