### PR TITLE
Add option to pass github_token for private repositories

### DIFF
--- a/pr-check/action.yml
+++ b/pr-check/action.yml
@@ -10,6 +10,9 @@ inputs:
   exclude:
     description: 'If set, will not check pull request that edit files under specified path'
     required: false
+  github_token:
+    description: 'Token to use for GitHub API requests'
+    required: false
 outputs:
   skipped:
     description: 'If true, means the pull request linting process has been skipped (thus no changelog update is needed)'

--- a/pr-check/index.js
+++ b/pr-check/index.js
@@ -137,14 +137,19 @@ async function run() {
     core.debug("Parse exclude parameter…");
     const excludeList = parseStringOrStringList(excludeParams);
     core.debug("Complete");
+    const githubToken = core.getInput("github_token") || null;
+    if (githubToken) core.debug("github_token is set");
 
     if (payload.hasOwnProperty('pull_request')) {
+      if(!payload.pull_request.body)
+        core.setFailed("Pull request description is empty");
+      
       const description = payload.pull_request.body.replace(/\r\n/g, '\n');
       const env = {
         owner: payload.repository.owner.login,
         repo: payload.repository.name,
         pull_number: payload.pull_request.number,
-        octokit: new Octokit(),
+        octokit: new Octokit({ auth: githubToken }),
       };
 
       const paths = await fetchChangedFiles(env);

--- a/pr-check/index.js
+++ b/pr-check/index.js
@@ -141,9 +141,11 @@ async function run() {
     if (githubToken) core.debug("github_token is set");
 
     if (payload.hasOwnProperty('pull_request')) {
-      if(!payload.pull_request.body)
-        core.setFailed("Pull request description is empty");
-      
+      if(!payload.pull_request.body) {
+        core.setFailed("Pull request description is empty.");
+        return;
+      }
+
       const description = payload.pull_request.body.replace(/\r\n/g, '\n');
       const env = {
         owner: payload.repository.owner.login,


### PR DESCRIPTION
Changed: Added new option `github_token` on the pr-check action, to allow passing API token for private repositories.
Changed: Updated error message to be more specific when PR description is empty.

Tested on both public (without `github_token`) and private (with `github_token`) and all working OK.